### PR TITLE
Wrap existing haskell cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +451,7 @@ dependencies = [
 name = "fission"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "base64 0.13.0",
  "bs58",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.66"
 bs58 = "0.4.0"
 base64 = "0.13.0"
 clap = { version = "3.2.12", features = ["derive"] }

--- a/src/cmd/app.rs
+++ b/src/cmd/app.rs
@@ -71,7 +71,7 @@ pub enum AppCommands {
         )]
         update_data: String,
         #[clap(
-            long = "udpate-dns",
+            long = "update-dns",
             help = "Update DNS",
             default_value = "True",
             value_name = "ARG"

--- a/src/cmd/app.rs
+++ b/src/cmd/app.rs
@@ -36,11 +36,15 @@ pub enum AppCommands {
         quiet: bool,
         #[clap(from_global)]
         verbose: bool,
+        #[clap(from_global)]
+        remote: Option<String>,
     },
     #[clap(about = "Detail about the current app")]
     Info {
         #[clap(from_global)]
         verbose: bool,
+        #[clap(from_global)]
+        remote: Option<String>,
     },
     #[clap(about = "Upload the working directory")]
     Publish {
@@ -82,6 +86,8 @@ pub enum AppCommands {
         update_dns: String,
         #[clap(from_global)]
         verbose: bool,
+        #[clap(from_global)]
+        remote: Option<String>,
     },
     #[clap(about = "Initialize an existing app")]
     Register {
@@ -117,6 +123,8 @@ pub enum AppCommands {
         ipfs_timeout: String,
         #[clap(from_global)]
         verbose: bool,
+        #[clap(from_global)]
+        remote: Option<String>,
     },
 }
 
@@ -146,6 +154,7 @@ pub fn run_command(a: App) -> Result<()> {
             potency,
             quiet,
             verbose,
+            remote,
         } => {
             // N.B. The wrapped app delegate command does not accept verbose
             let flags = prepare_flags(&[("-q", &quiet)]);
@@ -154,6 +163,7 @@ pub fn run_command(a: App) -> Result<()> {
                 ("-d", did.as_ref()),
                 ("-l", Some(lifetime.to_string()).as_ref()),
                 ("-p", Some(potency.to_string()).as_ref()),
+                ("-R", remote.as_ref()),
             ]);
 
             Command::new("fission")
@@ -165,11 +175,13 @@ pub fn run_command(a: App) -> Result<()> {
 
             Ok(())
         }
-        AppCommands::Info { verbose } => {
+        AppCommands::Info { verbose, remote} => {
             let flags = prepare_flags(&[("-v", &verbose)]);
+            let args = prepare_args(&[("-R", remote.as_ref())]);
 
             Command::new("fission")
                 .args(["app", "info"])
+                .args(args)
                 .args(flags)
                 .spawn()?
                 .wait()?;
@@ -185,6 +197,7 @@ pub fn run_command(a: App) -> Result<()> {
             update_data,
             update_dns,
             verbose,
+            remote,
         } => {
             let flags = prepare_flags(&[("-o", &open), ("-w", &watch), ("-v", &verbose)]);
             let args = prepare_args(&[
@@ -192,6 +205,7 @@ pub fn run_command(a: App) -> Result<()> {
                 ("--ipfs-timeout", Some(ipfs_timeout).as_ref()),
                 ("--update-data", Some(update_data).as_ref()),
                 ("--update-dns", Some(update_dns).as_ref()),
+                ("-R", remote.as_ref()),
             ]);
 
             Command::new("fission")
@@ -211,6 +225,7 @@ pub fn run_command(a: App) -> Result<()> {
             ipfs_bin,
             ipfs_timeout,
             verbose,
+            remote,
         } => {
             let flags = prepare_flags(&[("-v", &verbose)]);
             let args = prepare_args(&[
@@ -219,6 +234,7 @@ pub fn run_command(a: App) -> Result<()> {
                 ("-n", name.as_ref()),
                 ("--ipfs-bin", ipfs_bin.as_ref()),
                 ("--ipfs-timeout", Some(ipfs_timeout).as_ref()),
+                ("-R", remote.as_ref()),
             ]);
 
             Command::new("fission")

--- a/src/cmd/app.rs
+++ b/src/cmd/app.rs
@@ -37,6 +37,8 @@ pub enum AppCommands {
         #[clap(short, long, help = "Only output the UCAN on success")]
         quiet: bool,
     },
+    #[clap(about = "Detail about the current app")]
+    Info,
     #[clap(about = "Upload the working directory")]
     Publish {
         #[clap(
@@ -129,6 +131,14 @@ pub fn run_command(a: App) -> Result<()> {
         } => {
             todo!("delegate")
         }
+        AppCommands::Info => {
+            Command::new("fission")
+                .args(["app", "info"])
+                .spawn()?
+                .wait()?;
+
+            Ok(())
+        }
         AppCommands::Publish {
             path,
             open,
@@ -138,10 +148,7 @@ pub fn run_command(a: App) -> Result<()> {
             update_data,
             update_dns,
         } => {
-            let flags = prepare_flags(&[
-                ("-o", &open),
-                ("-w", &watch)
-            ]);
+            let flags = prepare_flags(&[("-o", &open), ("-w", &watch)]);
 
             let args = prepare_args(&[
                 ("--ipfs-bin", ipfs_bin.as_ref()),

--- a/src/cmd/app.rs
+++ b/src/cmd/app.rs
@@ -1,7 +1,7 @@
 use crate::legacy::{prepare_args, prepare_flags};
 use anyhow::Result;
 use clap::{ArgEnum, Args, Subcommand};
-use std::process::Command;
+use std::{collections::HashMap, process::Command};
 
 #[derive(Args)]
 pub struct App {
@@ -156,32 +156,34 @@ pub fn run_command(a: App) -> Result<()> {
             verbose,
             remote,
         } => {
-            // N.B. The wrapped app delegate command does not accept verbose
-            let flags = prepare_flags(&[("-q", &quiet)]);
-            let args = prepare_args(&[
+            let args = prepare_args(&HashMap::from([
                 ("-a", app_name.as_ref()),
                 ("-d", did.as_ref()),
                 ("-l", Some(lifetime.to_string()).as_ref()),
                 ("-p", Some(potency.to_string()).as_ref()),
-                ("-R", remote.as_ref()),
-            ]);
+            ]));
+            let remote = prepare_args(&HashMap::from([("-R", remote.as_ref())]));
+
+            // N.B. The wrapped app delegate command does not accept verbose
+            let flags = prepare_flags(&HashMap::from([("-q", quiet)]));
 
             Command::new("fission")
                 .args(["app", "delegate"])
                 .args(args)
+                .args(remote)
                 .args(flags)
                 .spawn()?
                 .wait()?;
 
             Ok(())
         }
-        AppCommands::Info { verbose, remote} => {
-            let flags = prepare_flags(&[("-v", &verbose)]);
-            let args = prepare_args(&[("-R", remote.as_ref())]);
+        AppCommands::Info { verbose, remote } => {
+            let remote = prepare_args(&HashMap::from([("-R", remote.as_ref())]));
+            let flags = prepare_flags(&HashMap::from([("-v", verbose)]));
 
             Command::new("fission")
                 .args(["app", "info"])
-                .args(args)
+                .args(remote)
                 .args(flags)
                 .spawn()?
                 .wait()?;
@@ -199,19 +201,24 @@ pub fn run_command(a: App) -> Result<()> {
             verbose,
             remote,
         } => {
-            let flags = prepare_flags(&[("-o", &open), ("-w", &watch), ("-v", &verbose)]);
-            let args = prepare_args(&[
+            let args = prepare_args(&HashMap::from([
                 ("--ipfs-bin", ipfs_bin.as_ref()),
                 ("--ipfs-timeout", Some(ipfs_timeout).as_ref()),
                 ("--update-data", Some(update_data).as_ref()),
                 ("--update-dns", Some(update_dns).as_ref()),
-                ("-R", remote.as_ref()),
-            ]);
+            ]));
+            let remote = prepare_args(&HashMap::from([("-R", remote.as_ref())]));
+            let flags = prepare_flags(&HashMap::from([
+                ("-o", open),
+                ("-w", watch),
+                ("-v", verbose),
+            ]));
 
             Command::new("fission")
                 .args(["app", "publish"])
                 .arg(path)
                 .args(args)
+                .args(remote)
                 .args(flags)
                 .spawn()?
                 .wait()?;
@@ -227,19 +234,20 @@ pub fn run_command(a: App) -> Result<()> {
             verbose,
             remote,
         } => {
-            let flags = prepare_flags(&[("-v", &verbose)]);
-            let args = prepare_args(&[
+            let args = prepare_args(&HashMap::from([
                 ("-a", Some(app_dir).as_ref()),
                 ("-b", build_dir.as_ref()),
                 ("-n", name.as_ref()),
                 ("--ipfs-bin", ipfs_bin.as_ref()),
                 ("--ipfs-timeout", Some(ipfs_timeout).as_ref()),
-                ("-R", remote.as_ref()),
-            ]);
+            ]));
+            let remote = prepare_args(&HashMap::from([("-R", remote.as_ref())]));
+            let flags = prepare_flags(&HashMap::from([("-v", verbose)]));
 
             Command::new("fission")
                 .args(["app", "register"])
                 .args(args)
+                .args(remote)
                 .args(flags)
                 .spawn()?
                 .wait()?;

--- a/src/cmd/setup.rs
+++ b/src/cmd/setup.rs
@@ -1,8 +1,29 @@
+use anyhow::Result;
 use clap::Args;
+use std::process::Command;
+use crate::legacy::prepare_args;
 
 #[derive(Args)]
 struct Setup {}
 
-pub fn run_command(username: Option<String>) {
-    todo!("setup --username={:?}", username)
+pub fn run_command(
+    username: Option<String>,
+    email: Option<String>,
+    keyfile: Option<String>,
+    os: Option<String>,
+) -> Result<()> {
+    let args = prepare_args(&[
+        ("-u", username.as_ref()),
+        ("-e", email.as_ref()),
+        ("-k", keyfile.as_ref()),
+        ("os", os.as_ref()),
+    ]);
+
+    Command::new("fission")
+        .arg("setup")
+        .args(args)
+        .spawn()?
+        .wait()?;
+
+    Ok(())
 }

--- a/src/cmd/setup.rs
+++ b/src/cmd/setup.rs
@@ -1,7 +1,7 @@
+use crate::legacy::{prepare_args, prepare_flags};
 use anyhow::Result;
 use clap::Args;
 use std::process::Command;
-use crate::legacy::prepare_args;
 
 #[derive(Args)]
 struct Setup {}
@@ -11,7 +11,9 @@ pub fn run_command(
     email: Option<String>,
     keyfile: Option<String>,
     os: Option<String>,
+    verbose: bool,
 ) -> Result<()> {
+    let flags = prepare_flags(&[("-v", &verbose)]);
     let args = prepare_args(&[
         ("-u", username.as_ref()),
         ("-e", email.as_ref()),
@@ -22,6 +24,7 @@ pub fn run_command(
     Command::new("fission")
         .arg("setup")
         .args(args)
+        .args(flags)
         .spawn()?
         .wait()?;
 

--- a/src/cmd/setup.rs
+++ b/src/cmd/setup.rs
@@ -12,6 +12,7 @@ pub fn run_command(
     keyfile: Option<String>,
     os: Option<String>,
     verbose: bool,
+    remote: Option<String>,
 ) -> Result<()> {
     let flags = prepare_flags(&[("-v", &verbose)]);
     let args = prepare_args(&[
@@ -19,6 +20,7 @@ pub fn run_command(
         ("-e", email.as_ref()),
         ("-k", keyfile.as_ref()),
         ("--os", os.as_ref()),
+        ("-R", remote.as_ref()),
     ]);
 
     Command::new("fission")

--- a/src/cmd/setup.rs
+++ b/src/cmd/setup.rs
@@ -1,7 +1,7 @@
 use crate::legacy::{prepare_args, prepare_flags};
 use anyhow::Result;
 use clap::Args;
-use std::process::Command;
+use std::{collections::HashMap, process::Command};
 
 #[derive(Args)]
 struct Setup {}
@@ -14,18 +14,19 @@ pub fn run_command(
     verbose: bool,
     remote: Option<String>,
 ) -> Result<()> {
-    let flags = prepare_flags(&[("-v", &verbose)]);
-    let args = prepare_args(&[
+    let args = prepare_args(&HashMap::from([
         ("-u", username.as_ref()),
         ("-e", email.as_ref()),
         ("-k", keyfile.as_ref()),
         ("--os", os.as_ref()),
-        ("-R", remote.as_ref()),
-    ]);
+    ]));
+    let remote = prepare_args(&HashMap::from([("-R", remote.as_ref())]));
+    let flags = prepare_flags(&HashMap::from([("-v", verbose)]));
 
     Command::new("fission")
         .arg("setup")
         .args(args)
+        .args(remote)
         .args(flags)
         .spawn()?
         .wait()?;

--- a/src/cmd/setup.rs
+++ b/src/cmd/setup.rs
@@ -18,7 +18,7 @@ pub fn run_command(
         ("-u", username.as_ref()),
         ("-e", email.as_ref()),
         ("-k", keyfile.as_ref()),
-        ("os", os.as_ref()),
+        ("--os", os.as_ref()),
     ]);
 
     Command::new("fission")

--- a/src/cmd/user.rs
+++ b/src/cmd/user.rs
@@ -17,19 +17,23 @@ pub enum UserCommands {
         username: Option<String>,
         #[clap(from_global)]
         verbose: bool,
+        #[clap(from_global)]
+        remote: Option<String>,
     },
     #[clap(about = "Display current user")]
     Whoami {
         #[clap(from_global)]
         verbose: bool,
+        #[clap(from_global)]
+        remote: Option<String>,
     },
 }
 
 pub fn run_command(u: User) -> Result<()> {
     match u.command {
-        UserCommands::Login { username, verbose } => {
+        UserCommands::Login { username, verbose, remote } => {
             let flags = prepare_flags(&[("-v", &verbose)]);
-            let args = prepare_args(&[("-u", username.as_ref())]);
+            let args = prepare_args(&[("-u", username.as_ref()), ("-R", remote.as_ref())]);
 
             Command::new("fission")
                 .args(["user", "login"])
@@ -40,11 +44,13 @@ pub fn run_command(u: User) -> Result<()> {
 
             Ok(())
         }
-        UserCommands::Whoami { verbose } => {
+        UserCommands::Whoami { verbose, remote } => {
             let flags = prepare_flags(&[("-v", &verbose)]);
+            let args = prepare_args(&[("-R", remote.as_ref())]);
 
             Command::new("fission")
                 .args(["user", "whoami"])
+                .args(args)
                 .args(flags)
                 .spawn()?
                 .wait()?;

--- a/src/cmd/user.rs
+++ b/src/cmd/user.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 #[derive(Args)]
 pub struct User {
     #[clap(subcommand)]
-    command: UserCommands,
+    pub command: UserCommands,
 }
 
 #[derive(Subcommand)]

--- a/src/cmd/user.rs
+++ b/src/cmd/user.rs
@@ -1,3 +1,4 @@
+use crate::legacy::prepare_args;
 use anyhow::Result;
 use clap::{Args, Subcommand};
 use std::process::Command;
@@ -21,8 +22,16 @@ pub enum UserCommands {
 
 pub fn run_command(u: User) -> Result<()> {
     match u.command {
-        UserCommands::Login { username: _ } => {
-            todo!("login")
+        UserCommands::Login { username } => {
+            let args = prepare_args(&[("-u", username.as_ref())]);
+
+            Command::new("fission")
+                .args(["user", "login"])
+                .args(args)
+                .spawn()?
+                .wait()?;
+
+            Ok(())
         }
         UserCommands::Whoami => {
             Command::new("fission")

--- a/src/cmd/user.rs
+++ b/src/cmd/user.rs
@@ -1,4 +1,6 @@
+use anyhow::Result;
 use clap::{Args, Subcommand};
+use std::process::Command;
 
 #[derive(Args)]
 pub struct User {
@@ -17,13 +19,18 @@ pub enum UserCommands {
     Whoami,
 }
 
-pub fn run_command(u: User) {
+pub fn run_command(u: User) -> Result<()> {
     match u.command {
         UserCommands::Login { username: _ } => {
             todo!("login")
         }
         UserCommands::Whoami => {
-            todo!("whoami")
+            Command::new("fission")
+                .args(["user", "whoami"])
+                .spawn()?
+                .wait()?;
+
+            Ok(())
         }
     }
 }

--- a/src/cmd/user.rs
+++ b/src/cmd/user.rs
@@ -1,4 +1,4 @@
-use crate::legacy::prepare_args;
+use crate::legacy::{prepare_args, prepare_flags};
 use anyhow::Result;
 use clap::{Args, Subcommand};
 use std::process::Command;
@@ -15,27 +15,37 @@ pub enum UserCommands {
     Login {
         #[clap(short, long, value_parser, help = "Username")]
         username: Option<String>,
+        #[clap(from_global)]
+        verbose: bool,
     },
     #[clap(about = "Display current user")]
-    Whoami,
+    Whoami {
+        #[clap(from_global)]
+        verbose: bool,
+    },
 }
 
 pub fn run_command(u: User) -> Result<()> {
     match u.command {
-        UserCommands::Login { username } => {
+        UserCommands::Login { username, verbose } => {
+            let flags = prepare_flags(&[("-v", &verbose)]);
             let args = prepare_args(&[("-u", username.as_ref())]);
 
             Command::new("fission")
                 .args(["user", "login"])
                 .args(args)
+                .args(flags)
                 .spawn()?
                 .wait()?;
 
             Ok(())
         }
-        UserCommands::Whoami => {
+        UserCommands::Whoami { verbose } => {
+            let flags = prepare_flags(&[("-v", &verbose)]);
+
             Command::new("fission")
                 .args(["user", "whoami"])
+                .args(flags)
                 .spawn()?
                 .wait()?;
 

--- a/src/cmd/user.rs
+++ b/src/cmd/user.rs
@@ -1,7 +1,7 @@
 use crate::legacy::{prepare_args, prepare_flags};
 use anyhow::Result;
 use clap::{Args, Subcommand};
-use std::process::Command;
+use std::{collections::HashMap, process::Command};
 
 #[derive(Args)]
 pub struct User {
@@ -31,13 +31,19 @@ pub enum UserCommands {
 
 pub fn run_command(u: User) -> Result<()> {
     match u.command {
-        UserCommands::Login { username, verbose, remote } => {
-            let flags = prepare_flags(&[("-v", &verbose)]);
-            let args = prepare_args(&[("-u", username.as_ref()), ("-R", remote.as_ref())]);
+        UserCommands::Login {
+            username,
+            verbose,
+            remote,
+        } => {
+            let args = prepare_args(&HashMap::from([("-u", username.as_ref())]));
+            let remote = prepare_args(&HashMap::from([("-R", remote.as_ref())]));
+            let flags = prepare_flags(&HashMap::from([("-v", verbose)]));
 
             Command::new("fission")
                 .args(["user", "login"])
                 .args(args)
+                .args(remote)
                 .args(flags)
                 .spawn()?
                 .wait()?;
@@ -45,12 +51,12 @@ pub fn run_command(u: User) -> Result<()> {
             Ok(())
         }
         UserCommands::Whoami { verbose, remote } => {
-            let flags = prepare_flags(&[("-v", &verbose)]);
-            let args = prepare_args(&[("-R", remote.as_ref())]);
+            let remote = prepare_args(&HashMap::from([("-R", remote.as_ref())]));
+            let flags = prepare_flags(&HashMap::from([("-v", verbose)]));
 
             Command::new("fission")
                 .args(["user", "whoami"])
-                .args(args)
+                .args(remote)
                 .args(flags)
                 .spawn()?
                 .wait()?;

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -1,0 +1,14 @@
+use std::iter::once;
+
+/// Convert argument tuples to a vector of argument strings.
+/// 
+/// This function is glue to reformat args parsed by CLAP for
+/// Command::args (https://doc.rust-lang.org/std/process/struct.Command.html#method.args).
+/// 
+/// It keeps optional arguments CLAP parsed as Some(arg) and drops None arguments.
+pub fn prepare_args(args: &[(&str, Option<&String>)]) -> Vec<String> {
+  args.iter()
+      .filter(|tup| tup.1.is_some())
+      .flat_map(|tup| once(tup.0.to_string()).chain(once(tup.1.unwrap().to_string())))
+      .collect()
+}

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -1,27 +1,28 @@
-use std::iter::once;
+use std::{collections::HashMap, iter::once};
 
-/// Convert flag tuples to a vector of flag strings
-/// 
+/// Convert flags to a vector of flag strings
+///
 /// This function is glue to reformat flags parsed by CLAP for
 /// Command::args (https://doc.rust-lang.org/std/process/struct.Command.html#method.args).
-/// 
+///
 /// It keeps flags CLAP parsed as True and drops False flags.
-pub fn prepare_flags(flags: &[(&str, &bool)]) -> Vec<String> {
-  flags.iter()
-      .filter(|tup| *tup.1)
-      .flat_map(|tup| once(tup.0.to_string()))
-      .collect()
+pub fn prepare_flags(flags: &HashMap<&str, bool>) -> Vec<String> {
+    flags
+        .iter()
+        .filter(|tup| *tup.1)
+        .flat_map(|tup| once(tup.0.to_string()))
+        .collect()
 }
 
-/// Convert argument tuples to a vector of argument strings.
-/// 
+/// Convert arguments to a vector of argument strings.
+///
 /// This function is glue to reformat args parsed by CLAP for
 /// Command::args (https://doc.rust-lang.org/std/process/struct.Command.html#method.args).
-/// 
+///
 /// It keeps optional arguments CLAP parsed as Some(arg) and drops None arguments.
-pub fn prepare_args(args: &[(&str, Option<&String>)]) -> Vec<String> {
-  args.iter()
-      .filter(|tup| tup.1.is_some())
-      .flat_map(|tup| once(tup.0.to_string()).chain(once(tup.1.unwrap().to_string())))
-      .collect()
+pub fn prepare_args(args: &HashMap<&str, Option<&String>>) -> Vec<String> {
+    args.iter()
+        .filter(|tup| tup.1.is_some())
+        .flat_map(|tup| once(tup.0.to_string()).chain(once(tup.1.unwrap().to_string())))
+        .collect()
 }

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -1,5 +1,18 @@
 use std::iter::once;
 
+/// Convert flag tuples to a vector of flag strings
+/// 
+/// This function is glue to reformat flags parsed by CLAP for
+/// Command::args (https://doc.rust-lang.org/std/process/struct.Command.html#method.args).
+/// 
+/// It keeps flags CLAP parsed as True and drops False flags.
+pub fn prepare_flags(flags: &[(&str, &bool)]) -> Vec<String> {
+  flags.iter()
+      .filter(|tup| *tup.1)
+      .flat_map(|tup| once(tup.0.to_string()))
+      .collect()
+}
+
 /// Convert argument tuples to a vector of argument strings.
 /// 
 /// This function is glue to reformat args parsed by CLAP for

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,3 @@
 pub mod cmd;
+pub mod legacy;
+pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,17 @@ enum Commands {
     Setup {
         #[clap(short, long, value_parser, help = "The username to register")]
         username: Option<String>,
+        #[clap(short, long, value_parser, help = "The email address for the account")]
+        email: Option<String>,
+        #[clap(
+            short,
+            long = "with-key",
+            value_parser,
+            help = "A root keyfile to import"
+        )]
+        keyfile: Option<String>,
+        #[clap(short, long, value_parser, help = "Override OS detection")]
+        os: Option<String>,
     },
     #[clap(about = "User application management")]
     User(User),
@@ -33,7 +44,15 @@ fn main() {
     match cli.command {
         Commands::App(a) => run_app_command(a),
         Commands::Generate(g) => run_generate_command(g),
-        Commands::Setup { username } => run_setup_command(username),
+        Commands::Setup {
+            username,
+            email,
+            keyfile,
+            os,
+        } => match run_setup_command(username, email, keyfile, os) {
+            Ok(()) => (),
+            Err(_err) => eprintln!("💥 Failed to execute setup command."),
+        },
         Commands::User(u) => run_user_command(u),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,10 @@ fn main() {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::App(a) => run_app_command(a),
+        Commands::App(a) => match run_app_command(a) {
+            Ok(()) => (),
+            Err(_err) => eprintln!("💥 Failed to execute app command."),
+        },
         Commands::Generate(g) => run_generate_command(g),
         Commands::Setup {
             username,

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,8 @@ use fission::cmd::{
 struct Cli {
     #[clap(short, long, global = true, help = "Print detailed output")]
     verbose: bool,
+    #[clap(short = 'R', long, global = true, hide = true)]
+    remote: Option<String>,
     #[clap(subcommand)]
     command: Commands,
 }
@@ -38,6 +40,8 @@ enum Commands {
         os: Option<String>,
         #[clap(from_global)]
         verbose: bool,
+        #[clap(short = 'R', long, global = true, hide = true)]
+        remote: Option<String>,
     },
     #[clap(about = "User application management")]
     User(User),
@@ -47,6 +51,8 @@ enum Commands {
     Whoami {
         #[clap(from_global)]
         verbose: bool,
+        #[clap(short = 'R', long, global = true, hide = true)]
+        remote: Option<String>,
     },
 }
 fn main() {
@@ -64,7 +70,8 @@ fn main() {
             keyfile,
             os,
             verbose,
-        } => match run_setup_command(username, email, keyfile, os, verbose) {
+            remote
+        } => match run_setup_command(username, email, keyfile, os, verbose, remote) {
             Ok(()) => (),
             Err(_err) => eprintln!("💥 Failed to execute setup command."),
         },
@@ -74,8 +81,8 @@ fn main() {
         },
 
         // Shortcuts
-        Commands::Whoami { verbose } => match run_user_command(User {
-            command: UserCommands::Whoami { verbose },
+        Commands::Whoami { verbose, remote } => match run_user_command(User {
+            command: UserCommands::Whoami { verbose, remote },
         }) {
             Ok(()) => (),
             Err(_err) => eprintln!("💥 Failed to execute whoami command.",),

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,11 @@ fn main() {
             Ok(()) => (),
             Err(_err) => eprintln!("💥 Failed to execute setup command."),
         },
-        Commands::User(u) => run_user_command(u),
+        Commands::User(u) => match run_user_command(u) {
+            Ok(()) => (),
+            Err(_err) => eprintln!(
+                "💥 Failed to execute user command.",
+            ),
+        },
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use fission::cmd::{
     app::{run_command as run_app_command, App},
     generate::{run_command as run_generate_command, Generate},
     setup::run_command as run_setup_command,
-    user::{run_command as run_user_command, User},
+    user::{run_command as run_user_command, User, UserCommands},
 };
 
 #[derive(Parser)]
@@ -37,6 +37,10 @@ enum Commands {
     },
     #[clap(about = "User application management")]
     User(User),
+
+    // Shortcuts
+    #[clap(about = "Display current user")]
+    Whoami,
 }
 fn main() {
     let cli = Cli::parse();
@@ -55,9 +59,15 @@ fn main() {
         },
         Commands::User(u) => match run_user_command(u) {
             Ok(()) => (),
-            Err(_err) => eprintln!(
-                "💥 Failed to execute user command.",
-            ),
+            Err(_err) => eprintln!("💥 Failed to execute user command.",),
+        },
+
+        // Shortcuts
+        Commands::Whoami => match run_user_command(User {
+            command: UserCommands::Whoami,
+        }) {
+            Ok(()) => (),
+            Err(_err) => eprintln!("💥 Failed to execute whoami command.",),
         },
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,8 @@ use fission::cmd::{
 #[derive(Parser)]
 #[clap(author, version, about="Fission makes developing, deploying, updating, and iterating on web apps quick and easy.", long_about = None)]
 struct Cli {
+    #[clap(short, long, global = true, help = "Print detailed output")]
+    verbose: bool,
     #[clap(subcommand)]
     command: Commands,
 }
@@ -34,13 +36,18 @@ enum Commands {
         keyfile: Option<String>,
         #[clap(short, long, value_parser, help = "Override OS detection")]
         os: Option<String>,
+        #[clap(from_global)]
+        verbose: bool,
     },
     #[clap(about = "User application management")]
     User(User),
 
     // Shortcuts
     #[clap(about = "Display current user")]
-    Whoami,
+    Whoami {
+        #[clap(from_global)]
+        verbose: bool,
+    },
 }
 fn main() {
     let cli = Cli::parse();
@@ -56,7 +63,8 @@ fn main() {
             email,
             keyfile,
             os,
-        } => match run_setup_command(username, email, keyfile, os) {
+            verbose,
+        } => match run_setup_command(username, email, keyfile, os, verbose) {
             Ok(()) => (),
             Err(_err) => eprintln!("💥 Failed to execute setup command."),
         },
@@ -66,8 +74,8 @@ fn main() {
         },
 
         // Shortcuts
-        Commands::Whoami => match run_user_command(User {
-            command: UserCommands::Whoami,
+        Commands::Whoami { verbose } => match run_user_command(User {
+            command: UserCommands::Whoami { verbose },
         }) {
             Ok(()) => (),
             Err(_err) => eprintln!("💥 Failed to execute whoami command.",),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,53 @@
+use anyhow::{anyhow, Result};
+use std::io::{self, Write};
+use std::process::Output;
+
+pub struct OutputOptions {
+    verbose: bool,
+    quiet: bool,
+    error: bool,
+}
+
+impl OutputOptions {
+    fn verbose() -> OutputOptions {
+        OutputOptions {
+            verbose: true,
+            quiet: false,
+            error: false,
+        }
+    }
+
+    fn default() -> OutputOptions {
+        OutputOptions {
+            verbose: false,
+            quiet: false,
+            error: false,
+        }
+    }
+
+    fn quiet() -> OutputOptions {
+        OutputOptions {
+            verbose: false,
+            quiet: true,
+            error: false,
+        }
+    }
+}
+
+pub fn write_output(output: &Output) -> Result<()> {
+    let mut options = OutputOptions::verbose();
+
+    if output.stdout != [] {
+        print_output(std::str::from_utf8(&output.stdout)?, &options)?;
+    }
+    if output.stderr != [] {
+        options.error = true;
+        print_output(std::str::from_utf8(&output.stdout)?, &options)?;
+    }
+    Ok(())
+}
+
+pub fn print_output(output: &str, options: &OutputOptions) -> Result<()> {
+    println!("{}", output);
+    Ok(())
+}


### PR DESCRIPTION
# Description

This PR implements initial CLI functionality by wrapping the existing Haskell CLI binary. Following this PR, we will implement each command natively in Rust. 🦀 

This PR implements the the following commands:

- [x] `fission setup`
- [x] `fission user whoami` (and a `fission whoami` alias)
- [x] `fission user login`
- [x] `fission app register`
- [x] `fission app info`
- [x] `fission app publish`
- [x] `fission app delegate`

It also implements the following global flags:

- [x] `--verbose`
- [x] `--remote`
- [x] `--help` (descriptions in attributes per command)

We also started to add a `src/utils.rs` module, but it is not used in the wrapped CLI implementation.

## Link to issue

Closes #6

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change that adds functionality)
- [x] Comments have been added

## Testing

Testing will be a bit manual, going through each command to see that it works. For each command, try some of the args and flags to see they work.

The recommended sequence is:

- Create a new user with `cargo run setup`
- Check the user is set up with `cargo run user whoami` and `cargo run whoami`
- Link the user to a browser with `cargo run user login`
- Register an app with `<path-to-binary> app register`
- Publish the app with `<path-to-binary> app publish`
- Get info on the app with `<path-to-binary> app info`
- Delegate access to the app with `<path-to-binary> app delegate`

The last `app` commands are best tested outside of the project directory, which is why`<path-to-binary>` is suggested for them. A temp directory with a text file can be created as a simple app to publish.

The `app delegate` command is slightly more involved than the other commands. At minimum, an app name and an audience must be specified. The app that was created and published while testing `app register` and `app publish` can be used for app name. The DID can be any valid `did:key`. For example:

```
<path-to-binary> app delegate -a short-old-tin-hero -d did:key:z6Mko4wBW851vmaB2VoA3dR6fisKK3Wn5bEWdhwnCw4yrRAm
```

The global `verbose` and `remote` commands can also be tested. Verbose is a bit easier and can be added along the way. Testing remote is essentially a separate pass through each of the commands.
